### PR TITLE
error handling

### DIFF
--- a/z3.sh
+++ b/z3.sh
@@ -17,9 +17,11 @@ export ANDROID_JACK_VM_ARGS="$JACK_SERVER_VM_ARGUMENTS"
 
 echo "--------jack args $ANDROID_JACK_VM_ARGS"
 echo "-----Trigger build from $PWD"
-source ./build/envsetup.sh
-breakfast z3
-mka bacon
+source ./build/envsetup.sh && breakfast z3 && mka bacon
+MKAERR=$?
 
 #kill jack when done to prevent error on other builds
 ./prebuilts/sdk/tools/jack-admin kill-server || true
+
+# exit with the result of mka
+exit $MKAERR


### PR DESCRIPTION
This will finish the script with the exit code of mka.

tbh I'm not sure what jenkins requires in line 27..

either use this added change here or:
- replace line 27 with: echo $MKAERR 
- or replace line 27 with: return $MKAERR

That's depending on how jenkins work (I'm still a jenkins noob..) 
but one of those should do ;) 

This commit also ensure that the whole chain get monitored:
source ./build/envsetup.sh && breakfast z3 && mka bacon

If one of these single command would fail the whole process fails 
and so the exitcode will be != 0 on any of those commands - which 
I would recommend.